### PR TITLE
Add support for LDAPS and LDAP Channel Binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@
 FROM python:3.10.4-slim-buster
 RUN pip install --upgrade pip
 RUN pip install certipy-ad
+RUN apt update && apt install git -y
+RUN pip3 install git+https://github.com/ly4k/ldap3
 WORKDIR /tmp

--- a/Readme.md
+++ b/Readme.md
@@ -19,3 +19,9 @@ sudo docker run -it -v $(pwd):/tmp certipy:latest certipy find -u 'user' -p 'pas
 ```bash
 sudo docker run -it -v $(pwd):/tmp --add-host=DC:10.10.90.78 certipy:latest certipy req -u 'user@domain.loc' -p "Password" -dc-ip 10.10.90.78 -target 'DC' -ca 'domain-DC-CA' -template 'RetroClients' -upn 'Administrator@domain.loc' -key-size 4096
 ```
+
+## Use LDAPS and LDAP Channel Binding
+
+```bash
+sudo docker run -it -v $(pwd):/tmp certipy:latest certipy find -u 'user' -p 'password' -scheme ldaps -ldap-channel-binding
+```


### PR DESCRIPTION
This PR installs and configures [ly4k's ldap3 library](https://github.com/ly4k/ldap3) which supports channel binding. This allows the container to run and leverage Certipy in an environment which enforces channel binding.